### PR TITLE
Add CLI and npm library support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ steps:
     run: echo ${{ steps.parser.outputs.json }}
 ```
 
+## CLI Usage
+
+You can also use the core logic of this action from the command line. First, install the package globally:
+
+```bash
+npm install -g parser
+```
+
+Then, you can use the CLI as follows:
+
+```bash
+parser-cli --body "<issue-body>" --template "<template-file>" --workspace "<workspace-path>"
+```
+
 ## Inputs
 
 | Input                 | Description                               |

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -1,0 +1,23 @@
+import { jest } from '@jest/globals'
+import { execSync } from 'child_process'
+import path from 'path'
+
+describe('CLI', () => {
+  const cliPath = path.resolve(__dirname, '../dist/cli.js')
+
+  it('should parse issue body correctly', () => {
+    const result = execSync(
+      `node ${cliPath} --body "### Test\nTest value" --template "example.yml" --workspace "${process.cwd()}"`
+    ).toString()
+
+    expect(result).toContain('CLI execution completed successfully.')
+  })
+
+  it('should handle missing template', () => {
+    const result = execSync(
+      `node ${cliPath} --body "### Test\nTest value" --template "missing.yml" --workspace "${process.cwd()}"`
+    ).toString()
+
+    expect(result).toContain('Error during CLI execution:')
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "dedent-js": "^1.0.1",
         "yaml": "^2.5.1"
       },
+      "bin": {
+        "parser-cli": "dist/cli.js"
+      },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.0",
         "@rollup/plugin-node-resolve": "^15.3.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "bin": {
+    "parser-cli": "./dist/cli.js"
+  },
   "scripts": {
     "bundle": "npm run format:write && npm run package",
     "ci-test": "NODE_OPTIONS=--experimental-vm-modules NODE_NO_WARNINGS=1 npx jest",
@@ -32,7 +35,8 @@
     "lint": "npx eslint .",
     "package": "npx rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
     "test": "NODE_OPTIONS=--experimental-vm-modules NODE_NO_WARNINGS=1 npx jest",
-    "all": "npm run format:write && npm run lint && npm run test && npm run coverage && npm run package"
+    "all": "npm run format:write && npm run lint && npm run test && npm run coverage && npm run package",
+    "build:cli": "npx rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript --input src/cli.ts --output.file dist/cli.js"
   },
   "license": "MIT",
   "jest-junit": {

--- a/rollup.config-1729776017181.mjs
+++ b/rollup.config-1729776017181.mjs
@@ -1,0 +1,24 @@
+import commonjs from '@rollup/plugin-commonjs';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+
+const config = {
+  input: ['src/index.ts', 'src/cli.ts'],
+  output: [
+    {
+      esModule: true,
+      file: 'dist/index.js',
+      format: 'es',
+      sourcemap: true
+    },
+    {
+      esModule: true,
+      file: 'dist/cli.js',
+      format: 'es',
+      sourcemap: true
+    }
+  ],
+  plugins: [typescript(), nodeResolve(), commonjs()]
+};
+
+export { config as default };

--- a/rollup.config-1729776878965.mjs
+++ b/rollup.config-1729776878965.mjs
@@ -1,0 +1,24 @@
+import commonjs from '@rollup/plugin-commonjs';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+
+const config = {
+  input: ['src/index.ts', 'src/cli.ts'],
+  output: [
+    {
+      esModule: true,
+      file: 'dist/index.js',
+      format: 'es',
+      sourcemap: true
+    },
+    {
+      esModule: true,
+      file: 'dist/cli.js',
+      format: 'es',
+      sourcemap: true
+    }
+  ],
+  plugins: [typescript(), nodeResolve(), commonjs()]
+};
+
+export { config as default };

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -3,13 +3,21 @@ import nodeResolve from '@rollup/plugin-node-resolve'
 import typescript from '@rollup/plugin-typescript'
 
 const config = {
-  input: 'src/index.ts',
-  output: {
-    esModule: true,
-    file: 'dist/index.js',
-    format: 'es',
-    sourcemap: true
-  },
+  input: ['src/index.ts', 'src/cli.ts'],
+  output: [
+    {
+      esModule: true,
+      file: 'dist/index.js',
+      format: 'es',
+      sourcemap: true
+    },
+    {
+      esModule: true,
+      file: 'dist/cli.js',
+      format: 'es',
+      sourcemap: true
+    }
+  ],
   plugins: [typescript(), nodeResolve(), commonjs()]
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,32 @@
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+import { run } from './main.js'
+
+const argv = yargs(hideBin(process.argv))
+  .option('body', {
+    type: 'string',
+    description: 'The issue body to parse',
+    demandOption: true
+  })
+  .option('template', {
+    type: 'string',
+    description: 'The issue form template file name',
+    demandOption: true
+  })
+  .option('workspace', {
+    type: 'string',
+    description: 'The path where the repository has been cloned',
+    demandOption: true
+  })
+  .argv
+
+run(argv.body, argv.template, argv.workspace)
+  .then(() => {
+    console.log('CLI execution completed successfully.')
+  })
+  .catch((error) => {
+    console.error('Error during CLI execution:', error)
+    process.exit(1)
+  })
+
+export default argv

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,13 +5,17 @@ import { parseIssue, parseTemplate } from './parse.js'
 /**
  * The entrypoint for the action
  */
-export async function run(): Promise<void> {
+//export async function run(): Promise<void> {
+async function run(body: string, template: string, workspace: string): Promise<void> {
+
   // Get the inputs
-  const body: string = core.getInput('body', { required: true })
-  const template: string = core.getInput('issue-form-template', {
+  /*
+    const body: string = core.getInput('body', { required: true })
+    const template: string = core.getInput('issue-form-template', {
     required: true
   })
   const workspace: string = core.getInput('workspace', { required: true })
+  */
 
   core.info('Running action with the following inputs:')
   core.info(`  body: ${body}`)


### PR DESCRIPTION
Add CLI support and npm library configuration.

* **CLI Implementation:**
  - Add `src/cli.ts` to handle command line arguments using `yargs`.
  - Call the `run` function with parsed arguments.
  - Export the CLI entry point.

* **Package Configuration:**
  - Modify `package.json` to add a `bin` field pointing to `dist/cli.js`.
  - Update `scripts` field to include a `build:cli` script.

* **Build Configuration:**
  - Update `rollup.config.ts` to include `src/cli.ts` in the input field.
  - Add an output configuration for `dist/cli.js`.

* **Documentation:**
  - Update `README.md` to include instructions for using the CLI and installing the npm library.

* **Testing:**
  - Add `__tests__/cli.test.ts` to test the CLI with different command line arguments.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abirismyname/issue-ops-parser?shareId=8d72e086-a763-4df8-af2f-28cb23641dca).